### PR TITLE
Fix cfdGravity / Adds cfdReadTransportProperties

### DIFF
--- a/pyFVM/src/fields/cfdGetDataArray.py
+++ b/pyFVM/src/fields/cfdGetDataArray.py
@@ -1,0 +1,39 @@
+def cfdGetDataArray(Region,field):
+
+    """Gets the phi values for Region.fields.field and returns a list of float elements
+
+
+    Attributes:
+        
+       Region (str): the cfd Region.
+       field (str): the field in Region.fluid
+       
+    Example usage:
+        
+        cfdGetDataArray(Region,'rho')
+        
+    TODO:
+       Missing treatment for volVectorFields
+       . 
+    """      
+    phiArray=[]
+
+
+    if Region.fluid[field]['type']=='surfaceScalarField':
+        phi = Region.fluid[field]['phi']
+        for iValue in phi:
+            phiArray.append(iValue[0])
+    
+    elif Region.fluid[field]['type']=='volScalarField':
+        phi = Region.fluid[field]['phi']
+        for iValue in phi:
+            phiArray.append(iValue[0])
+
+    
+    elif Region.fluid[field]['type']=='volVectorField':
+        phi = Region.fluid[field]['phi']
+ 
+    
+    
+    return phiArray
+

--- a/pyFVM/src/fields/cfdGetFieldScale.py
+++ b/pyFVM/src/fields/cfdGetFieldScale.py
@@ -1,0 +1,21 @@
+def cfdGetFieldScale(Region,field):
+    
+    """Returns the scale of a field in Region. 
+    
+    
+    Attributes:
+    
+       Region (str): the cfd Region.
+       field (str): field of interest
+       
+    Example usage:
+    
+    cfdGetFieldScale(Region,'rho')
+    
+    TODO:
+       
+       . 
+    """
+    scale = Region.fluid[field].scale
+    
+    return scale

--- a/pyFVM/src/fields/cfdGetMeshField.py
+++ b/pyFVM/src/fields/cfdGetMeshField.py
@@ -1,0 +1,29 @@
+def cfdGetMeshField(Region,field):
+    """Returns the field dictionary in Region.fluid['field']. 
+
+
+    Attributes:
+        
+       Region (str): the cfd Region.
+       field (str): the field in Region.fluid
+
+    Example usage:
+        
+        rhoField=cfdGetMeshField(Region,'rho')
+        
+    TODO:
+        
+        Add fallback
+        
+       . 
+    """    
+    
+    if field in Region.fluid.keys():
+        fieldDict=Region.fluid[field]
+        
+    else:
+        fieldDict=-1
+        
+    return fieldDict
+        
+    

--- a/pyFVM/src/fields/cfdSetMeshField.py
+++ b/pyFVM/src/fields/cfdSetMeshField.py
@@ -4,5 +4,4 @@ def cfdSetMeshField(Region, theMeshField):
     """Adds the input field data (i.e., theMeshField) as a Region.fluid subdict.
     
     """
-    
     Region.fluid[theMeshField['name']] = theMeshField

--- a/pyFVM/src/fields/cfdUpdateScale.py
+++ b/pyFVM/src/fields/cfdUpdateScale.py
@@ -1,0 +1,55 @@
+def cfdUpdateScale(Region,field):
+
+    """Update the min, max and scale values of a field in Region
+
+
+    Attributes:
+        
+       Region (str): the cfd Region.
+       field (str): the field in Region.fields
+       
+    Example usage:
+        
+        cfdUpdateScale(Region,'rho')
+        
+    TODO:
+       
+       . 
+    """    
+        
+    from pyFVM.src.fields.cfdGetDataArray import cfdGetDataArray
+    from pyFVM.src.fields.cfdGetFieldScale import cfdGetFieldScale
+    from pyFVM.src.region.cfdGeometricLengthScale import cfdGeometricLengthScale
+    from pyFVM.src.math.cfdMag import cfdMag
+    
+    
+    phi=cfdGetDataArray(Region,field)
+    theMagnitude = cfdMag(phi)
+    
+    try:
+        iter(theMagnitude)
+        phiMax=max(cfdMag(phi))
+        phiMin=min(cfdMag(phi))
+
+
+    except TypeError:
+        phiMax=theMagnitude
+        phiMin=theMagnitude
+            
+    if field=='p':
+        vel_scale = cfdGetFieldScale('U')
+        rho_scale = cfdGetFieldScale('rho')
+        p_dyn = 0.5 * rho_scale * vel_scale^2
+        phiScale = max(phiMax,p_dyn)
+    
+    elif field=='U':
+        phiScale = max(cfdGeometricLengthScale,phiMax)
+    else: 
+        phiScale = phiMax
+    
+    
+    Region.fluid[field]['max']=phiMax
+    Region.fluid[field]['min']=phiMin
+    Region.fluid[field]['scale']=phiScale
+
+

--- a/pyFVM/src/math/cfdMag.py
+++ b/pyFVM/src/math/cfdMag.py
@@ -1,0 +1,36 @@
+def cfdMag(valueVector):
+    
+    """Returns the magnitude of a vector or list of vectors
+    
+    
+    Attributes:
+    
+       valueVector
+       
+    Example usage:
+    
+    cfdGetVolumesForElements(U)
+    
+    TODO:
+       
+       . 
+    """
+
+    import numpy as np
+   
+    
+    
+    try:
+        iter(valueVector[0])
+        result = []
+        for iVector in valueVector:
+            dotProduct = np.vdot(iVector,iVector)
+            magnitude = np.sqrt(dotProduct)
+            result.append(magnitude)
+       
+    except TypeError:   
+        dotProduct = np.vdot(valueVector,valueVector)
+        magnitude = np.sqrt(dotProduct)
+        result = magnitude
+        
+    return result

--- a/pyFVM/src/mesh/cfdGetVolumesForElements.py
+++ b/pyFVM/src/mesh/cfdGetVolumesForElements.py
@@ -1,0 +1,20 @@
+def cfdGetVolumesForElements(Region):
+    
+    """Returns the list of element Volumes
+    
+    
+    Attributes:
+    
+       Region (str): the cfd Region.
+       
+    Example usage:
+    
+    cfdGetVolumesForElements(Region)
+    
+    TODO:
+       
+       . 
+    """
+    elementVolumes = Region.mesh['elementVolumes']
+
+    return elementVolumes

--- a/pyFVM/src/region/cfdGeometricLengthScale.py
+++ b/pyFVM/src/region/cfdGeometricLengthScale.py
@@ -1,0 +1,25 @@
+def cfdGeometricLengthScale(Region):
+    
+    """Returns the scale of a field in Region. 
+    
+    
+    Attributes:
+    
+       Region (str): the cfd Region.
+       field (str): field of interest
+       
+    Example usage:
+    
+    cfdGetFieldScale(Region,'rho')
+    
+    TODO:
+       
+       . 
+    """
+    from pyFVM.src.mesh.cfdGetVolumesForElements import cfdGetVolumesForElements
+    
+    
+    totalVolume = sum(cfdGetVolumesForElements)
+    lengthScale = totalVolume ^ (1/3)
+
+    return lengthScale

--- a/pyFVM/utilities/IO/Foam/cfdReadGravity.py
+++ b/pyFVM/utilities/IO/Foam/cfdReadGravity.py
@@ -1,3 +1,4 @@
+import os
 from pyFVM.utilities.IO.File.cfdReadAllDictionaries import cfdReadAllDictionaries
 
 def cfdReadGravity(Region):
@@ -18,32 +19,37 @@ def cfdReadGravity(Region):
        
        . 
     """    
-
-
+    
     gravityFilePath=Region.caseDirectoryPath + "/constant/g"
     
-    gravityDict = cfdReadAllDictionaries(gravityFilePath)
+    if not os.path.isfile(gravityFilePath):
+        print('\n\nNo g file found\n')
+        pass
     
-    dimensions=[]
-    for iEntry in gravityDict['dimensions']:
+    else:
+        print('\n\nReading Gravity ...\n')        
+        gravityDict = cfdReadAllDictionaries(gravityFilePath)
         
-        try:
-            dimensions.append(float(iEntry))
-        except ValueError:
-            pass
-    
-    value=[]
-    for iEntry in gravityDict['value']:
-    
-        iEntry=iEntry.replace("(","")
-        iEntry=iEntry.replace(")","")
+        dimensions=[]
+        for iEntry in gravityDict['dimensions']:
+            
+            try:
+                dimensions.append(float(iEntry))
+            except ValueError:
+                pass
         
-        try:
-            value.append(float(iEntry))
-        except ValueError:
-            pass
-    
-    Region.foamDictionary['g']={}
-    
-    Region.foamDictionary['g']['dimensions']=dimensions
-    Region.foamDictionary['g']['value']=value
+        value=[]
+        for iEntry in gravityDict['value']:
+        
+            iEntry=iEntry.replace("(","")
+            iEntry=iEntry.replace(")","")
+            
+            try:
+                value.append(float(iEntry))
+            except ValueError:
+                pass
+        
+        Region.foamDictionary['g']={}
+        
+        Region.foamDictionary['g']['dimensions']=dimensions
+        Region.foamDictionary['g']['value']=value

--- a/pyFVM/utilities/IO/Foam/cfdReadTransportProperties.py
+++ b/pyFVM/utilities/IO/Foam/cfdReadTransportProperties.py
@@ -1,0 +1,200 @@
+import os
+from pyFVM.src.fields.cfdGetMeshField import cfdGetMeshField
+from pyFVM.src.fields.cfdSetMeshField import cfdSetMeshField
+from pyFVM.src.fields.cfdUpdateScale import cfdUpdateScale
+from pyFVM.utilities.IO.File.cfdReadAllDictionaries import cfdReadAllDictionaries
+
+def cfdReadTransportProperties(Region):
+    """Reads the transportProperties dictionary 
+       and sets the transportProperties in Region.fluid
+
+       If rho, mu and Cp dictionaries are not user defined, creates them with default air properties
+       Same for k (thermal conductivity) if the DT dictionary is present
+
+
+    Attributes:
+        
+       Region (instance of cfdSetupRegion): the cfd Region.
+       
+    Example usage:
+        
+        cfdReadTransportProperties(Region)
+        
+    TODO:
+       
+       . 
+    """ 
+
+
+
+    
+    transportPropertiesFilePath=Region.caseDirectoryPath+"/constant/transportProperties"
+    
+    
+    if not os.path.isfile(transportPropertiesFilePath):
+        pass
+    
+    else:
+        print('Reading transport properties ...')
+        
+        transportDicts=cfdReadAllDictionaries(transportPropertiesFilePath)
+        transportKeys=list(transportDicts)   
+        
+        Region.foamDictionary['transportProperties']={}
+        
+        for iKey in transportKeys:
+            if iKey=='FoamFile' or iKey=='cfdTransportModel':
+                pass
+            elif not len(transportDicts[iKey])==8:
+                print('FATAL: There is a problem with entry %s in transportProperties' %iKey )
+                break
+            else:
+     
+                theMeshField={}
+                dimVector=[]
+                boundaryPatch={} 
+                Region.foamDictionary['transportProperties'][iKey]={}
+                
+                for iDim in transportDicts[iKey][0:7]:
+                    dimVector.append(float(iDim))
+    
+                keyValue = float(transportDicts[iKey][7])
+                
+                theInteriorArraySize = Region.mesh['numberOfElements']
+                theBoundaryArraySize = Region.mesh['numberOfBElements']
+    
+                theMeshField['phi']= [[keyValue] for i in range(theInteriorArraySize+theBoundaryArraySize)] 
+                theMeshField['name']=iKey
+                theMeshField['type']='volScalarField'
+                theMeshField['dimensions']=transportDicts[iKey][0:7]
+                theMeshField['prevIter']={}
+                theMeshField['prevIter']['phi']=theMeshField['phi']   
+                theMeshField['prevTimeStep']={}
+                theMeshField['prevTimeStep']['phi']=theMeshField['phi']
+          
+                numberOfBPatches=int(Region.mesh['numberOfBoundaryPatches'])
+                for iPatch in range(0,numberOfBPatches):
+                    boundaryPatch['value'] = keyValue;
+                    boundaryPatch['type'] = 'zeroGradient';
+                    theMeshField['boundaryPatch'] = boundaryPatch;
+        
+                cfdSetMeshField(Region,theMeshField)
+                
+                Region.foamDictionary['transportProperties'][iKey]['name']=iKey
+                Region.foamDictionary['transportProperties'][iKey]['propertyValue']=keyValue
+                Region.foamDictionary['transportProperties'][iKey]['dimensions']=transportDicts[iKey][0:7]
+    
+                cfdUpdateScale(Region,iKey)
+                
+        if not 'rho' in transportKeys:
+            theMeshField={}
+            dimVector=[]
+            boundaryPatch={} 
+                        
+            theInteriorArraySize = Region.mesh['numberOfElements']
+            theBoundaryArraySize = Region.mesh['numberOfBElements']
+    
+            theMeshField['phi']= [[1.] for i in range(theInteriorArraySize+theBoundaryArraySize)] 
+            theMeshField['name']='rho'
+            theMeshField['type']='volScalarField'
+            theMeshField['dimensions']=['0', '0', '0', '0', '0', '0', '0'] #['1', '-3', '0', '0', '0', '0', '0']
+            theMeshField['prevIter']={}
+            theMeshField['prevIter']['phi']=theMeshField['phi']   
+            theMeshField['prevTimeStep']={}
+            theMeshField['prevTimeStep']['phi']=theMeshField['phi']
+      
+            numberOfBPatches=int(Region.mesh['numberOfBoundaryPatches'])
+            for iPatch in range(0,numberOfBPatches):
+                boundaryPatch['value'] = 1;
+                boundaryPatch['type'] = 'zeroGradient';
+                theMeshField['boundaryPatch'] = boundaryPatch;
+    
+            cfdSetMeshField(Region,theMeshField)
+            
+            cfdUpdateScale(Region,'rho')
+                 
+        Region.compressible='false' 
+    
+        if not 'mu' in transportKeys:
+            theMeshField={}
+            dimVector=[]
+            boundaryPatch={} 
+                        
+            theInteriorArraySize = Region.mesh['numberOfElements']
+            theBoundaryArraySize = Region.mesh['numberOfBElements']
+    
+            theMeshField['phi']= [[1E-3] for i in range(theInteriorArraySize+theBoundaryArraySize)] 
+            theMeshField['name']='mu'
+            theMeshField['type']='volScalarField'
+            theMeshField['dimensions']=['0', '0', '0', '0', '0', '0', '0'] #['1', '-3', '0', '0', '0', '0', '0']
+            theMeshField['prevIter']={}
+            theMeshField['prevIter']['phi']=theMeshField['phi']   
+            theMeshField['prevTimeStep']={}
+            theMeshField['prevTimeStep']['phi']=theMeshField['phi']
+      
+            numberOfBPatches=int(Region.mesh['numberOfBoundaryPatches'])
+            for iPatch in range(0,numberOfBPatches):
+                boundaryPatch['value'] = 1E-3;
+                boundaryPatch['type'] = 'zeroGradient';
+                theMeshField['boundaryPatch'] = boundaryPatch;
+    
+            cfdSetMeshField(Region,theMeshField)
+                 
+        if not 'Cp' in transportKeys:
+            theMeshField={}
+            dimVector=[]
+            boundaryPatch={} 
+                        
+            theInteriorArraySize = Region.mesh['numberOfElements']
+            theBoundaryArraySize = Region.mesh['numberOfBElements']
+    
+            theMeshField['phi']= [[1004.] for i in range(theInteriorArraySize+theBoundaryArraySize)] 
+            theMeshField['name']='Cp'
+            theMeshField['type']='volScalarField'
+            theMeshField['dimensions']=['0', '0', '0', '0', '0', '0', '0'] #['1', '-3', '0', '0', '0', '0', '0']
+            theMeshField['prevIter']={}
+            theMeshField['prevIter']['phi']=theMeshField['phi']   
+            theMeshField['prevTimeStep']={}
+            theMeshField['prevTimeStep']['phi']=theMeshField['phi']
+      
+            numberOfBPatches=int(Region.mesh['numberOfBoundaryPatches'])
+            for iPatch in range(0,numberOfBPatches):
+                boundaryPatch['value'] = 1004.;
+                boundaryPatch['type'] = 'zeroGradient';
+                theMeshField['boundaryPatch'] = boundaryPatch;
+    
+            cfdSetMeshField(Region,theMeshField)
+    
+        if not 'k' in transportKeys:
+            if 'DT' in transportKeys:
+                theMeshField={}
+                dimVector=[]
+                boundaryPatch={} 
+                kField=[]
+                theInteriorArraySize = Region.mesh['numberOfElements']
+                theBoundaryArraySize = Region.mesh['numberOfBElements']
+    
+                DTField = cfdGetMeshField(Region,'DT')['phi']
+                CpField = cfdGetMeshField(Region,'Cp')['phi']
+                rhoField = cfdGetMeshField(Region,'rho')['phi']
+    
+                
+                for i in range(0,len(DTField)):            
+                    kField.append([DTField[i][0]*CpField[i][0]*rhoField[i][0]])                    
+    
+                theMeshField['phi']= kField
+                theMeshField['name']='k'
+                theMeshField['type']='volScalarField'
+                theMeshField['dimensions']=['0', '0', '0', '0', '0', '0', '0'] #['1', '-3', '0', '0', '0', '0', '0']
+                theMeshField['prevIter']={}
+                theMeshField['prevIter']['phi']=theMeshField['phi']   
+                theMeshField['prevTimeStep']={}
+                theMeshField['prevTimeStep']['phi']=theMeshField['phi']
+          
+                numberOfBPatches=int(Region.mesh['numberOfBoundaryPatches'])
+                for iPatch in range(0,numberOfBPatches):
+                    boundaryPatch['value'] = kField[0];
+                    boundaryPatch['type'] = 'zeroGradient';
+                    theMeshField['boundaryPatch'] = boundaryPatch;
+        
+                cfdSetMeshField(Region,theMeshField)


### PR DESCRIPTION
The first commit fixes a bug with cfdReadGravity where the function threw and error if the g file wasn't there. 

The second one adds the cfdReadTransportProperties function as well as several required functions: 

- cfdGetFieldScale
- cfdGetMeshField
- cfdGetDataArray
- cfdMag
- cfdUpdateScale
- cfdGetVolumesForElements
- cfdGetGeometricLengthScale
- creates ./src/math folder

I tested it on tutorials/incompressible/bump and it seems to return the same as the matlab code. 